### PR TITLE
feat: add game selector for game masters during countdown

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.parallel=true
 minecraft_version=1.21.11
 loader_version=0.18.2
 loom_version=1.14-SNAPSHOT
-mod_version=0.77.0
+mod_version=0.78.0
 minecraft_compat=1.21.11
 
 # Mod Properties

--- a/src/main/java/work/lclpnet/lobby/activity/GameStartingActivity.java
+++ b/src/main/java/work/lclpnet/lobby/activity/GameStartingActivity.java
@@ -28,10 +28,12 @@ import work.lclpnet.lobby.LobbyMod;
 import work.lclpnet.lobby.cmd.PauseCommand;
 import work.lclpnet.lobby.cmd.ResumeCommand;
 import work.lclpnet.lobby.cmd.StartCommand;
+import work.lclpnet.lobby.game.GameManager;
 import work.lclpnet.lobby.game.LobbyWaitingManager;
 import work.lclpnet.lobby.game.api.Game;
 import work.lclpnet.lobby.game.api.GameConfig;
 import work.lclpnet.lobby.game.start.GameStarter;
+import work.lclpnet.lobby.game.start.LobbyArgs;
 import work.lclpnet.lobby.util.LobbyGameContext;
 
 import javax.inject.Named;
@@ -50,7 +52,8 @@ public class GameStartingActivity extends ComponentActivity {
 
     @AssistedInject
     public GameStartingActivity(MinecraftServer server, Logger logger, @Named("lobbyWorld") ServerLevel world,
-                                @Assisted Game game, @Assisted GameStarter starter, @Assisted Translations translations) {
+                                GameManager gameManager, @Assisted Game game, @Assisted GameStarter starter,
+                                @Assisted Translations translations, @Assisted LobbyArgs lobbyArgs) {
         super(server, logger);
         this.game = game;
         this.config = game.getConfig();
@@ -58,7 +61,7 @@ public class GameStartingActivity extends ComponentActivity {
         this.translations = translations;
 
         var context = new LobbyGameContext(server, game.getConfig(), translations);
-        this.waitingManager = new LobbyWaitingManager(world, context, starter);
+        this.waitingManager = new LobbyWaitingManager(world, context, starter, gameManager, lobbyArgs.getChangeGameConsumer());
     }
 
     @Override
@@ -185,8 +188,17 @@ public class GameStartingActivity extends ComponentActivity {
         }
     }
 
+    @Override
+    public void stop() {
+        super.stop();
+
+        for (ServerPlayer player : PlayerLookup.all(getServer())) {
+            player.getInventory().clearContent();
+        }
+    }
+
     @AssistedFactory
     public interface Builder {
-        GameStartingActivity create(Game game, GameStarter starter, Translations translations);
+        GameStartingActivity create(Game game, GameStarter starter, Translations translations, LobbyArgs lobbyArgs);
     }
 }

--- a/src/main/java/work/lclpnet/lobby/activity/LobbyActivity.java
+++ b/src/main/java/work/lclpnet/lobby/activity/LobbyActivity.java
@@ -245,7 +245,7 @@ public class LobbyActivity extends ComponentActivity {
     private void activateGame(Game game, GameFactory factory, Translations translations) {
         var environment = new FinishableGameEnvironment(getServer(), getLogger(), game.getConfig(), translations);
 
-        var args = new LobbyArgs(childActivity, configurator);
+        var args = new LobbyArgs(childActivity, configurator, this::changeGame);
         var scope = new Scope(getServer());
 
         synchronized (this) {
@@ -259,7 +259,7 @@ public class LobbyActivity extends ComponentActivity {
                 factory.createInstance(environment).start(options);
             }, environment);
 
-            args.injectStartingSupplier(() -> startingBuilder.create(game, gameStarter, translations));
+            args.injectStartingSupplier(() -> startingBuilder.create(game, gameStarter, translations, args));
 
             gameStarter.start();
         }

--- a/src/main/java/work/lclpnet/lobby/game/LobbyWaitingManager.java
+++ b/src/main/java/work/lclpnet/lobby/game/LobbyWaitingManager.java
@@ -5,8 +5,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.server.permissions.Permission;
-import net.minecraft.server.permissions.PermissionLevel;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
@@ -24,6 +22,8 @@ import work.lclpnet.kibu.access.entity.ServerPlayerAccess;
 import work.lclpnet.kibu.hook.HookRegistrar;
 import work.lclpnet.kibu.hook.entity.PlayerInteractionHooks;
 import work.lclpnet.kibu.hook.player.PlayerConnectionHooks;
+import work.lclpnet.kibu.inv.prompt.OptionPrompt;
+import work.lclpnet.lobby.game.api.Game;
 import work.lclpnet.lobby.game.api.GameContext;
 import work.lclpnet.lobby.game.api.option.*;
 import work.lclpnet.lobby.game.start.GameStarter;
@@ -32,6 +32,7 @@ import work.lclpnet.lobby.util.Interactable;
 import work.lclpnet.lobby.util.Voting;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 public class LobbyWaitingManager implements GameOptionConfig, GameOptions {
 
@@ -41,11 +42,16 @@ public class LobbyWaitingManager implements GameOptionConfig, GameOptions {
     private final List<Voting<?>> votings = new ArrayList<>();
     private final Map<UUID, PlayerState> states = new HashMap<>();
     private final Map<Integer, Set<Runnable>> timedActions = new HashMap<>();
+    private final GameManager gameManager;
+    private final Consumer<Game> changeGameConsumer;
 
-    public LobbyWaitingManager(ServerLevel world, GameContext context, GameStarter starter) {
+    public LobbyWaitingManager(ServerLevel world, GameContext context, GameStarter starter,
+                               GameManager gameManager, Consumer<Game> changeGameConsumer) {
         this.world = world;
         this.context = context;
         this.starter = starter;
+        this.gameManager = gameManager;
+        this.changeGameConsumer = changeGameConsumer;
     }
 
     @Override
@@ -160,12 +166,16 @@ public class LobbyWaitingManager implements GameOptionConfig, GameOptions {
         Inventory inventory = player.getInventory();
         PlayerState state = getState(player);
 
-        if (GameConstants.DEVELOPMENT && Commands.LEVEL_GAMEMASTERS.check(context.getServer().getProfilePermissions(player.nameAndId()))) {
-            Interactable startAction = p -> startGame();
+        if (Commands.LEVEL_GAMEMASTERS.check(context.getServer().getProfilePermissions(player.nameAndId()))) {
+            int gameSlot = state.getFreeSlot(8);
+            inventory.setItem(gameSlot, getGameSelectorStack(player));
+            state.setInteractable(gameSlot, this::openGameSelector);
 
-            int slot = state.getFirstFreeSlot();
-            inventory.setItem(slot, getStartStack(player));
-            state.setInteractable(slot, startAction);
+            if (GameConstants.DEVELOPMENT) {
+                int slot = state.getFirstFreeSlot();
+                inventory.setItem(slot, getStartStack(player));
+                state.setInteractable(slot, p -> startGame());
+            }
         }
 
         if (votings.size() == 1) {
@@ -198,6 +208,29 @@ public class LobbyWaitingManager implements GameOptionConfig, GameOptions {
                 .formatted(ChatFormatting.GREEN));
 
         return stack;
+    }
+
+    private ItemStack getGameSelectorStack(ServerPlayer player) {
+        var stack = new ItemStack(Items.COMPASS);
+        stack.set(DataComponents.ITEM_NAME, context.getTranslations().translateText(player, "lobby.item.select_game")
+                .formatted(ChatFormatting.GOLD));
+        return stack;
+    }
+
+    private void openGameSelector(ServerPlayer player) {
+        var games = new ArrayList<>(gameManager.getGames());
+        var title = context.getTranslations().translateText(player, "lobby.item.select_game")
+                .formatted(ChatFormatting.GOLD);
+
+        OptionPrompt.open(player, title, games, game -> {
+            var icon = game.getConfig().icon().copy();
+            icon.set(DataComponents.ITEM_NAME, context.getTranslations()
+                    .translateText(player, game.getConfig().titleKey())
+                    .formatted(ChatFormatting.AQUA));
+            return icon;
+        }).thenAccept(selected -> selected.ifPresent(game -> {
+            context.getServer().execute(() -> changeGameConsumer.accept(game));
+        }));
     }
 
     private PlayerState getState(ServerPlayer player) {

--- a/src/main/java/work/lclpnet/lobby/game/start/LobbyArgs.java
+++ b/src/main/java/work/lclpnet/lobby/game/start/LobbyArgs.java
@@ -4,6 +4,7 @@ import work.lclpnet.activity.Activity;
 import work.lclpnet.activity.manager.ActivityManager;
 import work.lclpnet.lobby.activity.GameStartingActivity;
 import work.lclpnet.lobby.activity.LobbyActivity;
+import work.lclpnet.lobby.game.api.Game;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -12,11 +13,17 @@ public class LobbyArgs implements GameStarter.Args {
 
     private final ActivityManager childActivity;
     private final LobbyGameConfigurator configurator;
+    private final Consumer<Game> changeGameConsumer;
     private Supplier<GameStartingActivity> startingSupplier = null;
 
-    public LobbyArgs(ActivityManager childActivity, LobbyGameConfigurator configurator) {
+    public LobbyArgs(ActivityManager childActivity, LobbyGameConfigurator configurator, Consumer<Game> changeGameConsumer) {
         this.childActivity = childActivity;
         this.configurator = configurator;
+        this.changeGameConsumer = changeGameConsumer;
+    }
+
+    public Consumer<Game> getChangeGameConsumer() {
+        return changeGameConsumer;
     }
 
     @Override

--- a/src/main/resources/assets/mg-lobby/lang/de_de.json
+++ b/src/main/resources/assets/mg-lobby/lang/de_de.json
@@ -21,6 +21,7 @@
   "lobby.voting.voted_for": "Du hast für %s gestimmt",
   "lobby.voting.votes": "Stimmen: %s",
   "lobby.item.start_game": "Spiel starten",
+  "lobby.item.select_game": "Spiel auswählen",
   "lobby.chat.wholesome.1": "Tolles Spiel, alle zusammen!",
   "lobby.chat.wholesome.2": "Es war mir eine Ehre, mit euch allen zu spielen. Danke.",
   "lobby.chat.wholesome.3": "Ich wünsche euch allen nur das Beste.",

--- a/src/main/resources/assets/mg-lobby/lang/en_us.json
+++ b/src/main/resources/assets/mg-lobby/lang/en_us.json
@@ -21,6 +21,7 @@
   "lobby.voting.voted_for": "You voted for %s",
   "lobby.voting.votes": "Votes: %s",
   "lobby.item.start_game": "Start game",
+  "lobby.item.select_game": "Select game",
   "lobby.chat.wholesome.1": "Great game, everyone!",
   "lobby.chat.wholesome.2": "It was an honor to play with you all. Thank you.",
   "lobby.chat.wholesome.3": "Wishing you all the best.",


### PR DESCRIPTION
Game masters can now switch games during the countdown phase via a compass item. Also clears player inventories on activity teardown to prevent stale items from carrying over.